### PR TITLE
Remove whole required jquery-ui lib

### DIFF
--- a/vendor/assets/stylesheets/gmaps-auto-complete.scss
+++ b/vendor/assets/stylesheets/gmaps-auto-complete.scss
@@ -1,5 +1,3 @@
-@import 'jquery-ui-1.8.16.custom.css';
-
 #gmaps-canvas {
   border: 1px solid #999;
   -moz-box-shadow:    0px 0px 5px #ccc;


### PR DESCRIPTION
No need to require the whole `jquery-ui` library. This was being pulled into a project and overwriting Bootstrap styles.